### PR TITLE
Mistypo.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version" : "1.1.0",
 	"description" : "returns a string containing a human-readable representation of object",
 	"main": "./jsDump",
-	"repostitory" : {
+	"repository" : {
 		"type" : "git",
 		"url" : "https://github.com/NV/jsDump"
 	}


### PR DESCRIPTION
npm warn: package.json: 'repostitory' should probably be 'repository'
