### PR TITLE
Fix the “arguments” object detection

### DIFF
--- a/jsDump.js
+++ b/jsDump.js
@@ -61,6 +61,9 @@ var jsDump;
 					case 'Array':
 						return 'array';
 
+					case 'Arguments':
+						return 'arguments';
+
 					case 'Date':
 						return 'date';
 
@@ -80,10 +83,7 @@ var jsDump;
 						return 'nodelist';
 
 					default:
-						if ( 'callee' in obj )
-							// Opera: Object.prototype.toString.call(arguments) == 'Object' :(
-							return 'arguments';
-						else if (window.jQuery && obj instanceof window.jQuery)
+						if (window.jQuery && obj instanceof window.jQuery)
 							return 'jquery';
 						else if ( 'ownerDocument' in obj && 'defaultView' in obj.ownerDocument && obj instanceof obj.ownerDocument.defaultView.Node )
 							return 'node';

--- a/tests/parse_test.js
+++ b/tests/parse_test.js
@@ -142,6 +142,60 @@ TESTS.arrays = [
 ];
 
 
+TESTS.arguments = [
+	{
+		input:  (function() { return arguments; })(),
+		result:"[]"
+	},
+	{
+		input:  (function() { return arguments; })(
+			[]
+		),
+		result:
+						"[\n   []\n]"
+	},
+	{
+		input:  (function() { return arguments; })(
+			[
+				[]
+			]
+		),
+		result:"[\n   [\n      []\n   ]\n]"
+	},
+	{
+		input:  (function() { return arguments; })(
+			[],
+			[],
+			[]
+		),
+		result:"[\n   [],\n   [],\n   []\n]"
+	},
+	{
+		input:  (function() { return arguments; })("Down", ["to", ["the", ["Rabbit", ["Hole"]]]]),
+		result:
+'[\n\
+   "Down",\n\
+   [\n\
+      "to",\n\
+      [\n\
+         "the",\n\
+         [\n\
+            "Rabbit",\n\
+            [\n\
+               "Hole"\n\
+            ]\n\
+         ]\n\
+      ]\n\
+   ]\n\
+]'
+	},
+	{
+		input:  new Array(3, 0, -1),
+		result: '[\n   3,\n   0,\n   -1\n]'
+	}
+];
+
+
 TESTS.functions = [
 	{
 		input:  function empty() {


### PR DESCRIPTION
Fixes #8 by detecting the `arguments` object using `Object.prototype.toString` instead of testing whether the `callee` property is present. Also covers `arguments` handling by tests (they are the same as the array ones).
